### PR TITLE
Fix git.gnome.org -> gitlab.gnome.org location for libxml2 submodule

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "gulp": "^3.9.0",
     "gulp-webserver": "^0.9.1",
     "minimist": "^1.2.0",
-    "xmllint": "git+https://github.com/kripken/xml.js.git"
+    "xmllint": "git+https://github.com/butchmarshall/xml.js.git#libxml2_submodule_fix"
   },
   "dependencies": {
     "framework7": "^1.5.2",


### PR DESCRIPTION
git.gnome.org was decommissioned, submodule no longer installs

https://mail.gnome.org/archives/desktop-devel-list/2018-August/msg00010.html

npm ERR! code 128
npm ERR! Command failed: /usr/bin/git submodule update -q --init --recursive
npm ERR! warning: templates not found /tmp/pacote-git-template-tmp/git-clone-ce68d33a
npm ERR! fatal: unable to connect to git.gnome.org:
npm ERR! git.gnome.org[0: 209.132.180.180]: errno=No route to host
npm ERR! git.gnome.org[1: 209.132.180.168]: errno=No route to host
npm ERR! 
npm ERR! fatal: clone of 'git://git.gnome.org/libxml2' into submodule path 'libxml2' failed
npm ERR! 

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/butch/.npm/_logs/2018-09-13T11_38_48_646Z-debug.lo